### PR TITLE
Remove dependency on BinaryData.h

### DIFF
--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -7,7 +7,7 @@
 
 namespace imagiro {
 
-    Processor::Processor(const juce::String& currentVersion, const juce::String& productSlug)
+    Processor::Processor(std::function<juce::String()> getParametersYAMLString, const juce::String& currentVersion, const juce::String& productSlug)
             : versionManager(currentVersion, productSlug),
               paramLoader(*this, getParametersYAMLString())
     {
@@ -15,6 +15,7 @@ namespace imagiro {
     }
 
     Processor::Processor(const juce::AudioProcessor::BusesProperties &ioLayouts,
+                         std::function<juce::String()> getParametersYAMLString,
                          const juce::String& currentVersion, const juce::String& productSlug)
             : ProcessorBase(ioLayouts),
               versionManager(currentVersion, productSlug),
@@ -275,15 +276,6 @@ namespace imagiro {
         for (auto parameter : getPluginParameters()) {
             parameter->prepareToPlay(sampleRate, samplesPerBlock);
         }
-    }
-
-    juce::String Processor::getParametersYAMLString() {
-#if JUCE_DEBUG && defined(SRCPATH)
-        auto file = juce::File(juce::String(SRCPATH) + "/Parameters.yaml");
-        return file.loadFileAsString();
-#else
-        return BinaryData::Parameters_yaml;
-#endif
     }
 
     float Processor::getCpuLoad() {

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -43,7 +43,7 @@ namespace imagiro {
         allParameters.add (rawPtr);
         parameterMap[p->getUID()] = rawPtr;
         if (p->isInternal()) internalParameters.add (p.release());
-        else addParameter (p.release());
+        else addParameter (p.release()->asJUCEParameter());
 
         return rawPtr;
     }

--- a/src/Processor.h
+++ b/src/Processor.h
@@ -12,7 +12,6 @@
 #include "config/VersionManager.h"
 #include "imagiro_processor/src/preset/FileBackedPreset.h"
 #include "imagiro_processor/src/config/Resources.h"
-#include "BinaryData.h"
 #include "imagiro_processor/src/parameter/ParameterLoader.h"
 
 class Preset;
@@ -20,9 +19,11 @@ class Preset;
 namespace imagiro {
     class Processor : public ProcessorBase, public Parameter::Listener {
     public:
-        Processor(const juce::String& currentVersion = "1.0.0",
+        Processor(std::function<juce::String()> getParametersYAMLString,
+                  const juce::String& currentVersion = "1.0.0",
                   const juce::String& productSlug = "");
         Processor(const juce::AudioProcessor::BusesProperties& ioLayouts,
+                  std::function<juce::String()> getParametersYAMLString,
                   const juce::String& currentVersion = "1.0.0",
                   const juce::String& productSlug = "");
 
@@ -94,7 +95,6 @@ namespace imagiro {
 
         void parameterChangedSync(imagiro::Parameter *param) override;
         std::map<juce::String, Parameter*> parameterMap;
-        virtual juce::String getParametersYAMLString();
 
         AuthorizationManager& getAuthManager() { return authManager; }
         VersionManager& getVersionManager() { return versionManager; }

--- a/src/parameter/ParameterLoader.cpp
+++ b/src/parameter/ParameterLoader.cpp
@@ -47,6 +47,10 @@ namespace imagiro {
     juce::NormalisableRange<float> ParameterLoader::getRange(juce::String parameterID, YAML::Node n) {
         auto type = getString(n, "type", "normal");
 
+        if (type == "freq") {
+            return getNormalisableRangeExp(20, 20000);
+        }
+
         auto min = getFloat(n, "min", 0);
         auto max = getFloat(n, "max", 1);
         auto step = getFloat(n, "step", 0);
@@ -57,14 +61,10 @@ namespace imagiro {
         if (type == "exp")
             return getNormalisableRangeExp(min, max, step);
 
-        if (type == "freq")
-            return getNormalisableRangeExp(20, 20000);
-
         if (type == "sync")
             return getTempoSyncRange(min, max, inverse);
 
-        return {min, max, step,
-                skew, symmetricSkew};
+        return {min, max, step, skew, symmetricSkew};
     }
 
 
@@ -209,23 +209,20 @@ namespace imagiro {
     std::unique_ptr<Parameter> ParameterLoader::loadParameter(const juce::String& uid, YAML::Node p,
                                                               const juce::String& namePrefix, int index) {
         auto name = namePrefix + str(p["name"]);
-        auto internal = getBool(p, "internal", false);
-        auto isMetaParameter = getBool(p, "meta", false);
+        auto isInternal = getBool(p, "internal", false);
+        auto isMeta = getBool(p, "meta", false);
+        auto isAutomatable = getBool(p, "automatable", true);
+        std::vector<ParameterConfig> configs;
 
         // Multi-configs
         if (p["configs"]) {
-            std::vector<ParameterConfig> configs;
-            for (auto config : p["configs"]) {
-                juce::String configName = config.first.as<std::string>();
-                configs.push_back(loadConfig(uid, configName, config.second, index));
-            }
-
-            return std::make_unique<Parameter>(uid, name, configs, isMetaParameter, internal);
+            for (auto config : p["configs"])
+                configs.push_back(loadConfig(uid, config.first.as<std::string>(), config.second, index));
+        } else {
+            // Single config
+            configs.push_back(loadConfig(uid, "default", p, index));
         }
 
-        // Single config
-        auto config = loadConfig(uid,"default", p, index);
-
-        return std::make_unique<Parameter>(uid, name, config, internal);
+        return std::make_unique<Parameter>(uid, name, configs, isMeta, isInternal, isAutomatable);
     }
 }

--- a/src/parameter/ParameterLoader.h
+++ b/src/parameter/ParameterLoader.h
@@ -9,15 +9,15 @@
 namespace imagiro {
     struct ParameterLoader {
         ParameterLoader(Processor& processor, const juce::String& YAMLString);
-        std::unique_ptr<imagiro::Parameter> loadParameter(
-                const juce::String& uid, YAML::Node paramNode, const juce::String& namePrefix = "", int index = 0);
 
         imagiro::ParameterConfig loadConfig(juce::String parameterName, juce::String name, YAML::Node p, int index = 0);
-        juce::NormalisableRange<float> getRange(juce::String parameterName, YAML::Node n);
-
-        Processor& processor;
 
     private:
+        std::unique_ptr<imagiro::Parameter> loadParameter(
+                const juce::String& uid, YAML::Node paramNode, const juce::String& namePrefix = "", int index = 0);
+        juce::NormalisableRange<float> getRange(juce::String parameterName, YAML::Node n);
         void load(const YAML::Node& config);
+
+        Processor& processor;
     };
 }


### PR DESCRIPTION
Similarly to https://github.com/augustpemberton/imagiro_webview/pull/2, let's not make the `imagiro::Processor` depend on `BinaryData.h`.

This is a bit trickier however since making `Processor::getParametersYAMLString()` fully virtual won't work: it's not allowed to call pure virtual methods in the constructor of a class, or at least it has undefined behaviour (and my compiler won't even let that happen), since at the very "top" of the constructor chain, the compiler doesn't know yet that the virtual function is overridden and doesn't know what it resolves to.

I had a chat with Cursor (my AI-IDE) about this, and it gave me a few alternatives. After exploring solution 1, I went with solution number 2 below, since solution 1 requires the Processor subclass constructor to call `paramLoader.load()` and `WebProcessor::init()` manually which felt like not great ergonomics. The reason being that failing to provide this lambda in the construction fails compilation, whereas failing to call `WebProcessor::init()` or calling it before param loading will not fail compilation but will give a broken processor object effectively... so I discounted that approach. Solution 3 has the name "factory" in it so I gave it short shrift :)

The only "downside" of this lambda approach is the lack of "default" value, but we can always throw in a default value for the lambda that does `return juce::File(juce::String(SRCPATH) + "/Parameters.yaml").loadFileAsString();` if we want. But at the same time, I don't see that as a downside because it's clear that this class is not meant to be instantiated on its own, but rather inherited from.

OOP is weird sometimes, man... :)

My chat with Cursor:

> Given the constraints and the requirement to call a function defined in [timeoffaudio::dime::Processor](file:///Users/moechaieb/src/timeoffaudio/plugins/plugins/dime/Processor.cpp#12%2C71-12%2C71) from the constructor of [imagiro::Processor](file:///Users/moechaieb/src/timeoffaudio/plugins/plugins/dime/Processor.cpp#83%2C13-83%2C13), and considering the challenge of virtual function calls within constructors, here are a few approaches to consider:
> ### 1. Initialization Function
> Instead of relying on the constructor to do all the work, you could define an initialization function in [imagiro::Processor](file:///Users/moechaieb/src/timeoffaudio/plugins/plugins/dime/Processor.cpp#83%2C13-83%2C13) that needs to be called explicitly after the object is constructed. This allows the derived class to be fully constructed before the function is called, thus avoiding the issue with virtual functions.
> ```cpp
> namespace imagiro {
>     class Processor {
>     public:
>         // Existing constructor
>         Processor(const juce::String& currentVersion = "1.0.0", const juce::String& productSlug = "");
> 
>         // New initialization method
>         virtual void initialize() = 0;
>     };
> }
> ```
> In `timeoffaudio::dime::Processor`, you override the `initialize` method:
> ```cpp:plugins/dime/Processor.cpp
> namespace timeoffaudio {
>     namespace dime {
>         void Processor::initialize() {
>             // Implementation specific to dime::Processor
>         }
>     }
> }
> ```
> After constructing a `Processor` object, you would then call `initialize()` on it.
> ### 2. Constructor Parameters
> Another approach is to pass a function or a functor to the constructor of `imagiro::Processor` that performs the necessary initialization. This can be a lambda capturing `[this]` if needed, allowing you to pass behavior from the derived class to the base class constructor.

> ```cpp
> namespace imagiro {
>     class Processor {
>     public:
>         Processor(std::function<void()> initFunction, const juce::String& currentVersion = "1.0.0", const juce::String& productSlug = "");
>     };
> }
> ```
> 
> In the constructor of `timeoffaudio::dime::Processor`, you pass a lambda that calls the desired function:
> 
> ```cpp
> namespace timeoffaudio {
>     namespace dime {
>         Processor::Processor()
>             : imagiro::Processor([this](){ this->myInitializationFunction(); }, "1.0.0", "productSlug") {
>             // Constructor body
>         }
> 
>         void Processor::myInitializationFunction() {
>             // Function content
>         }
>     }
> }
> ```
> 
> ### 3. Post-Construction Initialization in Factory Method
> 
> If changing the constructor signature of `imagiro::Processor` is not desirable, you could use a factory method pattern. This involves creating the `Processor` object and then calling an initialization method on it. This approach is more manual but avoids altering the constructor's signature.
> 
> ```cpp
> namespace imagiro {
>     class ProcessorFactory {
>     public:
>         static std::unique_ptr<Processor> createProcessor() {
>             auto processor = std::make_unique<timeoffaudio::dime::Processor>();
>             processor->initialize();
>             return processor;
>         }
>     };
> }
> ```
> 
> This approach requires that the `initialize` method is public and that you control the creation of `Processor` objects through the factory to ensure `initialize` is always called.
> 
> ### Conclusion
> 
> Each of these solutions has its trade-offs in terms of design purity, ease of use, and safety. The choice depends on your specific requirements, such as whether you can modify the base class, need to keep the API stable, or have other constraints.