### PR TITLE
Cleanup imagiro::Parameter API

### DIFF
--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -43,7 +43,7 @@ namespace imagiro {
         allParameters.add (rawPtr);
         parameterMap[p->getUID()] = rawPtr;
         if (p->isInternal()) internalParameters.add (p.release());
-        else addParameter (p.release());
+        else addParameter (p.release()->asJUCEParameter());
 
         return rawPtr;
     }

--- a/src/parameter/ParameterLoader.cpp
+++ b/src/parameter/ParameterLoader.cpp
@@ -47,6 +47,10 @@ namespace imagiro {
     juce::NormalisableRange<float> ParameterLoader::getRange(juce::String parameterID, YAML::Node n) {
         auto type = getString(n, "type", "normal");
 
+        if (type == "freq") {
+            return getNormalisableRangeExp(20, 20000);
+        }
+
         auto min = getFloat(n, "min", 0);
         auto max = getFloat(n, "max", 1);
         auto step = getFloat(n, "step", 0);
@@ -57,14 +61,10 @@ namespace imagiro {
         if (type == "exp")
             return getNormalisableRangeExp(min, max, step);
 
-        if (type == "freq")
-            return getNormalisableRangeExp(20, 20000);
-
         if (type == "sync")
             return getTempoSyncRange(min, max, inverse);
 
-        return {min, max, step,
-                skew, symmetricSkew};
+        return {min, max, step, skew, symmetricSkew};
     }
 
 
@@ -209,23 +209,20 @@ namespace imagiro {
     std::unique_ptr<Parameter> ParameterLoader::loadParameter(const juce::String& uid, YAML::Node p,
                                                               const juce::String& namePrefix, int index) {
         auto name = namePrefix + str(p["name"]);
-        auto internal = getBool(p, "internal", false);
-        auto isMetaParameter = getBool(p, "meta", false);
+        auto isInternal = getBool(p, "internal", false);
+        auto isMeta = getBool(p, "meta", false);
+        auto isAutomatable = getBool(p, "automatable", true);
+        std::vector<ParameterConfig> configs;
 
         // Multi-configs
         if (p["configs"]) {
-            std::vector<ParameterConfig> configs;
-            for (auto config : p["configs"]) {
-                juce::String configName = config.first.as<std::string>();
-                configs.push_back(loadConfig(uid, configName, config.second, index));
-            }
-
-            return std::make_unique<Parameter>(uid, name, configs, isMetaParameter, internal);
+            for (auto config : p["configs"])
+                configs.push_back(loadConfig(uid, config.first.as<std::string>(), config.second, index));
+        } else {
+            // Single config
+            configs.push_back(loadConfig(uid, "default", p, index));
         }
 
-        // Single config
-        auto config = loadConfig(uid,"default", p, index);
-
-        return std::make_unique<Parameter>(uid, name, config, internal);
+        return std::make_unique<Parameter>(uid, name, configs, isMeta, isInternal, isAutomatable);
     }
 }

--- a/src/parameter/ParameterLoader.h
+++ b/src/parameter/ParameterLoader.h
@@ -9,15 +9,15 @@
 namespace imagiro {
     struct ParameterLoader {
         ParameterLoader(Processor& processor, const juce::String& YAMLString);
-        std::unique_ptr<imagiro::Parameter> loadParameter(
-                const juce::String& uid, YAML::Node paramNode, const juce::String& namePrefix = "", int index = 0);
 
         imagiro::ParameterConfig loadConfig(juce::String parameterName, juce::String name, YAML::Node p, int index = 0);
-        juce::NormalisableRange<float> getRange(juce::String parameterName, YAML::Node n);
-
-        Processor& processor;
 
     private:
+        std::unique_ptr<imagiro::Parameter> loadParameter(
+                const juce::String& uid, YAML::Node paramNode, const juce::String& namePrefix = "", int index = 0);
+        juce::NormalisableRange<float> getRange(juce::String parameterName, YAML::Node n);
         void load(const YAML::Node& config);
+
+        Processor& processor;
     };
 }


### PR DESCRIPTION
The cleanup is based on one main thing: let's make the `imagiro::Parameter` class inherit from `juce::RangedAudioParameter` _privately_ instead of publicly. Why? This lets us define a much smaller public API. However, I did add an "escape-hatch" method called `imagiro::Parameter::asJUCEParameter` which will actually return a pointer to itself as `juce::RangedAudioParameter`. This is only needed in the imagiro::Processor to actually register the parameter with the processor. 

But otherwise, this lets us actually reduce the surface area of the imagiro::Processor API quite significantly within the imagiro_* libraries (i.e. this library itself and the webview library). I think this is a very good thing as it makes it harder for us to shoot ourselves in the foot by making it harder to mis-use the public API of `juce::RangedAudioParameter` and cause bugs.

This is especially true since outside of the imagiro::Parameter internals, the class actually seems to have a pretty small _de-facto_ public API in imagiro_processor and imagiro_webview (i.e. actually used public methods).

Now, this does mean we have some breaking changes on imagiro::Parameter:

- No longer exposing `beginChangeGesture` and `endChangeGesture` from the JUCE parameter class directly, instead we have our own `beginUserAction` and `endUserAction`. Internally, we still make the right calls.
- No longer exposing JUCE's `setValueNotifyingHost`, instead we have our own `setValueAndNotifyHost` (which again calls `setValueNotifyingHost` internally, wrapping it in our own logic.

To address these, here's a [PR to make breaking changes fixes in imagiro_webview](https://github.com/augustpemberton/imagiro_webview/pull/4). This will likely need to be addressed in your plugins as well, but from my understanding of the class, this shouldn't be anything major.

Otherwise, I've sprinkled the diff with the thought process behind other changes as I ended up taking this as an opportunity to clean up things a bit (getting rid of juce::Timer to handle async callbacks, removing the redundant constructor, etc). But the main thought process behind it was this API change I explain above.

Feel free to push back on any of these changes, or explain if I'm missing any context. Also feel free to add your own commits on top to undo bits and pieces, or make additional changes as you see fit.