### PR TITLE
Store parameter choices in ParameterConfiguration

### DIFF
--- a/src/parameter/ParameterConfig.h
+++ b/src/parameter/ParameterConfig.h
@@ -18,5 +18,6 @@ namespace imagiro {
         std::function<float(const Parameter&, juce::String)> valueFunction {nullptr};
         juce::String name {"default"};
         bool reverse {false};
+        std::vector<std::string> choices;
     };
 }

--- a/src/parameter/ParameterLoader.cpp
+++ b/src/parameter/ParameterLoader.cpp
@@ -171,6 +171,7 @@ namespace imagiro {
                 return std::find(choices.begin(), choices.end(), choice) - choices.begin();
             };
             config.range = {0, (float)choices.size()-1, 1};
+            config.choices = choices;
         } else if (type == "ratio") {
             auto ratioParams = p["ratio"];
             juce::String ratioParamName = ratioParams["name"].as<std::string>();


### PR DESCRIPTION
Without passing along `choices` from the Parameters.yaml along into the Javascript-side inside the payload of `juce_getPluginParameters`, we have no good way of accessing the textual values of these choices. These values are needed for generating drop-down menus for instance.

Obviously the range will reflect the discrete nature of the parameter choices, but we won't have the labels of those choices available to preload without doing something like setting the parameter value to each possible discrete step and calling `juce_getDisplayValue` at load time. This is the only way to get these textual values with the current API, and it seems a bit wasteful and unorthodox (since it will get called every time the UI is instantiated). 

Storing the choices in the `ParameterConfiguration` and serializing them inside the `ParameterAttachment::getParameterSpecValue` payload is much more efficient and straight-forward. Webview PR: https://github.com/augustpemberton/imagiro_webview/pull/5