### PR TITLE
Make IMAGIRO_SKIP_AUTH flag more comprehensive

### DIFF
--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -172,7 +172,9 @@ namespace imagiro {
 #if JucePlugin_IsSynth
         buffer.clear();
 #endif
+#ifndef IMAGIRO_SKIP_AUTH
         if (!authManager.isAuthorized()) return;
+#endif
 
         for (auto param : getPluginParameters()) {
             param->startBlock(buffer.getNumSamples());

--- a/src/Processor.h
+++ b/src/Processor.h
@@ -98,15 +98,17 @@ namespace imagiro {
         void parameterChanged(imagiro::Parameter *param) override;
         void configChanged(imagiro::Parameter *param) override;
         std::map<juce::String, Parameter*> parameterMap;
-
+#ifndef IMAGIRO_SKIP_AUTH
         AuthorizationManager& getAuthManager() { return authManager; }
-
+#endif
         float getCpuLoad();
 
         juce::String& getCurrentVersion() { return currentVersion; }
 
     protected:
+    #ifndef IMAGIRO_SKIP_AUTH
         AuthorizationManager authManager;
+    #endif
         juce::SharedResourcePointer<Resources> resources;
 
         juce::String currentVersion;

--- a/src/config/AuthorizationManager.cpp
+++ b/src/config/AuthorizationManager.cpp
@@ -4,6 +4,7 @@
 
 #include "AuthorizationManager.h"
 
+#ifndef IMAGIRO_SKIP_AUTH
 AuthorizationManager::AuthorizationManager()
 {
     loadSavedAuth();
@@ -22,10 +23,11 @@ bool AuthorizationManager::isAuthorized(bool ignoreDemo) {
         else return false;
     }
 
-#ifdef SKIP_AUTH
+#ifdef IMAGIRO_BYPASS_AUTH
     return true;
-#endif
+#else
     return isAuthorizedCache;
+#endif
 }
 
 bool AuthorizationManager::tryAuth(const juce::String& serial) {
@@ -137,3 +139,4 @@ void AuthorizationManager::logout() {
     getProperties()->removeValue("serial");
     isAuthorizedCache = false;
 }
+#endif

--- a/src/config/AuthorizationManager.h
+++ b/src/config/AuthorizationManager.h
@@ -6,6 +6,7 @@
 #include <juce_data_structures/juce_data_structures.h>
 #include "Resources.h"
 
+#ifndef IMAGIRO_SKIP_AUTH
 class AuthorizationManager {
 public:
     AuthorizationManager();
@@ -44,3 +45,4 @@ private:
     juce::SharedResourcePointer<Resources> resources;
     std::unique_ptr<juce::PropertiesFile>& getProperties() { return resources->getConfigFile(); }
 };
+#endif

--- a/src/preset/FileBackedPreset.h
+++ b/src/preset/FileBackedPreset.h
@@ -33,5 +33,3 @@ private:
 
 //    juce::SharedResourcePointer<Resources> resources;
 };
-
-


### PR DESCRIPTION
- Rename `SKIP_AUTH` flag to `IMAGIRO_BYPASS_AUTH`
- Add a new `IMAGIRO_SKIP_AUTH` flag which guts out the AuthManager out of the code at compile time

Using `IMAGIRO_BYPASS_AUTH` should do exactly the same thing as `SKIP_AUTH` before.

Using `IMAGIRO_SKIP_AUTH` will completely remove all auth related code from the imagiro stack (Same has been added on the webview side: https://github.com/augustpemberton/imagiro_webview/pull/8)