### PR TITLE
Add getBypassParameter() definition to imagiro::Processor

### DIFF
--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -312,4 +312,11 @@ namespace imagiro {
         }
     }
     void Processor::audioProcessorParameterChanged(AudioProcessor *processor, int parameterIndex, float newValue) {}
+
+    juce::AudioProcessorParameter* Processor::getBypassParameter() const {
+        if (const std::string bypassUID = "bypass"; parameterMap.contains (bypassUID))
+            return parameterMap.at(bypassUID)->asJUCEParameter();
+
+        return nullptr;
+    }
 }

--- a/src/Processor.h
+++ b/src/Processor.h
@@ -101,6 +101,7 @@ namespace imagiro {
         std::map<juce::String, Parameter*> parameterMap;
 
         float getCpuLoad();
+        juce::AudioProcessorParameter* getBypassParameter() const override;
 
         juce::String& getCurrentVersion() { return currentVersion; }
 


### PR DESCRIPTION
Let's define this as the juce::AudioProcessor expects it: https://docs.juce.com/master/classAudioProcessor.html#a08975ed39146521de90f52aa52ba3f9e.

Not strictly necessary I guess, and I haven't tested which DAWs actually leverage this properly (for instance, by linking the DAW's bypass button for the plugin to this as I would expect it to do).

But still, I like having this here for completeness.