### PR TITLE
Simplify latency compensation during bypass

### DIFF
--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -213,16 +213,10 @@ namespace imagiro {
             }
         }
 
-        for (auto c=0; c<dryBuffer.getNumChannels(); c++) {
-            dryBuffer.copyFrom(c, 0,
-                               buffer.getReadPointer(c),
-                               buffer.getNumSamples());
-        }
+        for (auto c=0; c<buffer.getNumChannels(); c++)
+            for(auto s=0; s<buffer.getNumSamples(); s++)
+                dryBufferLatencyCompensationLine.pushSample(c, buffer.getSample(c, s));
 
-        juce::dsp::AudioBlock<float> dryBlock { dryBuffer };
-        const juce::dsp::ProcessContextReplacing context { dryBlock };
-
-        dryBufferLatencyCompensationLine.process(context);
 
         {
             juce::AudioProcessLoadMeasurer::ScopedTimer s(measurer);
@@ -234,9 +228,9 @@ namespace imagiro {
         // apply bypass
         for (auto s=0; s<buffer.getNumSamples(); s++) {
             auto gain = bypassGain.getNextValue();
-            for (auto c=0; c<dryBuffer.getNumChannels(); c++) {
+            for (auto c=0; c<buffer.getNumChannels(); c++) {
                 auto v = buffer.getSample(c, s) * (1-gain);
-                v += dryBuffer.getSample(c, s) * gain;
+                v += dryBufferLatencyCompensationLine.popSample(c) * gain;
                 buffer.setSample(c, s, v);
             }
         }
@@ -290,10 +284,10 @@ namespace imagiro {
 
     void Processor::prepareToPlay(double sampleRate, int samplesPerBlock) {
         measurer.reset(sampleRate, samplesPerBlock);
-        dryBuffer.setSize(getTotalNumOutputChannels(), samplesPerBlock);
         dryBufferLatencyCompensationLine.prepare({
             sampleRate, static_cast<juce::uint32> (samplesPerBlock), static_cast<juce::uint32> (getTotalNumOutputChannels())
         });
+        dryBufferLatencyCompensationLine.setDelay(getLatencySamples());
 
         for (auto parameter : getPluginParameters()) {
             parameter->prepareToPlay(sampleRate, samplesPerBlock);

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -213,7 +213,7 @@ namespace imagiro {
             }
         }
 
-        for (auto c=0; c<buffer.getNumChannels(); c++)
+        for (auto c=0; c < getTotalNumOutputChannels(); c++)
             for(auto s=0; s<buffer.getNumSamples(); s++)
                 dryBufferLatencyCompensationLine.pushSample(c, buffer.getSample(c, s));
 
@@ -228,7 +228,7 @@ namespace imagiro {
         // apply bypass
         for (auto s=0; s<buffer.getNumSamples(); s++) {
             auto gain = bypassGain.getNextValue();
-            for (auto c=0; c<buffer.getNumChannels(); c++) {
+            for (auto c=0; c<getTotalNumOutputChannels(); c++) {
                 auto v = buffer.getSample(c, s) * (1-gain);
                 v += dryBufferLatencyCompensationLine.popSample(c) * gain;
                 buffer.setSample(c, s, v);

--- a/src/Processor.h
+++ b/src/Processor.h
@@ -129,7 +129,6 @@ namespace imagiro {
         juce::OwnedArray<Parameter> internalParameters;
 
         juce::SmoothedValue<float> bypassGain;
-        juce::AudioSampleBuffer dryBuffer;
         const int MAX_DELAY_LINES_SAMPLES_DURATION = 48000 * 4;
         juce::dsp::DelayLine<float> dryBufferLatencyCompensationLine { MAX_DELAY_LINES_SAMPLES_DURATION };
 


### PR DESCRIPTION
See conversation in Discord: https://discord.com/channels/1182053363890794516/1182053363890794519/1292136144229896232

TL;DR: FL Studio and Cubase were not happy with `juce::DelayLine::process(juce::dsp::ProcessContext&)`, for a reason I did not fully investigate.

Instead, using the pushSample/popSample API gives an clean result. It also has the upside of not requiring to maintain a separate `dryBuffer`, as we will now use the delay line internal buffer itself as the dry buffer.